### PR TITLE
Dvm update

### DIFF
--- a/src/disputable_values_monitor/cli.py
+++ b/src/disputable_values_monitor/cli.py
@@ -2,6 +2,7 @@
 import logging
 import warnings
 from time import sleep
+import time
 
 from decimal import *
 import os
@@ -32,13 +33,20 @@ from disputable_values_monitor.utils import get_tx_explorer_url
 from disputable_values_monitor.utils import select_account
 from disputable_values_monitor.utils import Topics
 
-from disputable_values_monitor.data import get_fetch_balance, get_pls_balance
-from disputable_values_monitor.utils import get_env_reporters_balance_threshold, get_reporters
+from disputable_values_monitor.data import get_fetch_balance, get_pls_balance, get_last_report
+from disputable_values_monitor.utils import get_env_reporters_balance_threshold, get_reporters, get_reporters_thresholds
 from disputable_values_monitor.utils import create_async_task
 from disputable_values_monitor.utils import fetch_dashboard
-from disputable_values_monitor.discord import token_balance_alert
+from disputable_values_monitor.discord import token_balance_alert, send_discord_msg
 
+#get wallet addresses for reporters to monitor
 reporters: list[str] = get_reporters()
+
+#get thresholds, in seconds, to check if a reporter has reported or not in X
+reporters_not_reporting_threshold: list[int] = get_reporters_thresholds()
+
+#set with alerts sent so not to double sent alerts
+reporter_stopped_alert_sent = set()
 
 def get_reporters_balance_threshold(reporters: list[str], env_variable_name: str):
     reporters_threshold: list[int] = get_env_reporters_balance_threshold(env_variable_name=env_variable_name)
@@ -155,23 +163,27 @@ async def start(
             topics=[Topics.NEW_REPORT],
             inital_block_offset=initial_block_offset,
         )
-        tellor_flex_report_events = await get_events(
-            cfg=cfg,
-            contract_name="tellorflex-oracle",
-            topics=[Topics.NEW_REPORT],
-            inital_block_offset=initial_block_offset,
-        )
+        ##If using tellorflex-oracle, remove comments.
+        
+        #tellor_flex_report_events = await get_events(
+            #cfg=cfg,
+            #contract_name="tellorflex-oracle",
+            #topics=[Topics.NEW_REPORT],
+            #inital_block_offset=initial_block_offset,
+        #)
         tellor360_events = await chain_events(
             cfg=cfg,
             # addresses are for token contract
             chain_addy={
                 #1: "0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0",
                 #11155111: "0x80fc34a2f9FfE86F41580F47368289C402DEc660",
+                #943: "0xC0573e2Fc47B26fb05097a553BBfcf0166bada0A",
+                #369: "0xe39B70c9978E4232140d148Ad3C0b08f4A42220D",
             },
             topics=[[Topics.NEW_ORACLE_ADDRESS], [Topics.NEW_PROPOSED_ORACLE_ADDRESS]],
             inital_block_offset=initial_block_offset,
         )
-        event_lists += tellor360_events + tellor_flex_report_events
+        event_lists += tellor360_events #+ tellor_flex_report_events
 
         reporters_pls_balance_task = create_async_task(
             update_reporters_pls_balance,
@@ -212,7 +224,15 @@ async def start(
                 disputer_account=account,
                 disputer_balances=disputer_balances
             )
-        )        
+        )
+        reporters_have_reported_task = create_async_task(
+            update_reporters_last_report,
+            cfg,
+            reporters,
+            reporters_not_reporting_threshold
+        )
+        reporters_have_reported_task.add_done_callback(lambda future: None)
+        
         for event_list in event_lists:
             # event_list = [(80001, EXAMPLE_NEW_REPORT_EVENT)]
             if not event_list:
@@ -245,7 +265,7 @@ async def start(
                     continue
                 displayed_events.add(new_report.tx_hash)
 
-                # Refesh
+                # Refresh
                 clear_console()
                 print_title_info()
 
@@ -305,6 +325,7 @@ async def start(
                 df["Value"] = df["Value"].apply(format_values)
                 print(df.to_markdown(index=False), end="\r")
                 df.to_csv("table.csv", mode="a", header=False)
+                click.echo("\n" + 204 * '_')
                 # reset config to clear object attributes that were set during loop
                 disp_cfg = AutoDisputerConfig(is_disputing=is_disputing, confidence_flag=confidence_threshold)
 
@@ -441,6 +462,53 @@ def alert_on_disputer_balances_threshold(
         )
         token_balance_alert(msg)
         disputer_balances[asset] = (balance, True)
+
+async def update_reporters_last_report(
+    telliot_config: TelliotConfig,
+    reporters,
+    reporters_not_reporting_threshold):
+    """
+    Checks the last reported time for each reporter and sends alerts if they haven't reported within the threshold.
+
+    Args:
+        telliot_config: TelliotConfig
+            reporters list[str]
+            reporters_not_reporting_threshold list[int]
+    """
+    global reporter_stopped_alert_sent
+    if not reporters or not reporters_not_reporting_threshold:
+        print("Error: 'REPORTERS' or 'NO_REPORTING_THRESHOLD' not found in .env file.")
+        logger.error("Error: 'REPORTERS' or 'NO_REPORTING_THRESHOLD' not found in .env file.")
+        return
+
+    if len(reporters) != len(reporters_not_reporting_threshold):
+        print("Error: The number of reporters and thresholds for when not reporting must match. Check .env")
+        logger.error("Error: The number of reporters and thresholds for when not reporting must match. Check .env")
+        return
+
+    for i in range(len(reporters)):
+        wallet_address = reporters[i]
+        time_threshold = reporters_not_reporting_threshold[i]
+        current_time = int(time.time())  #gets a fresh timestamp for calcs
+
+        last_report = await get_last_report(telliot_config, wallet_address)
+        time_since_report = current_time - last_report
+
+        if time_since_report > time_threshold:
+            if wallet_address not in reporter_stopped_alert_sent:
+                msg = (
+                    f"\n❗Reporter may have stopped❗\n"
+                    f"**{wallet_address}** has not reported in: "
+                    f"{time_since_report} seconds. \n**Last report was:** "
+                    f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(last_report))} (Timestamp: {last_report}).\n"
+                    f"**Threshold set to send alert:** {time_threshold} seconds without a new report."
+                )
+                send_discord_msg(msg)
+                reporter_stopped_alert_sent.add(wallet_address)  # Add wallet to the set after sending the alert
+        else:
+            # If the reporter has reported recently, remove them from the alert set
+            if wallet_address in reporter_stopped_alert_sent:
+                reporter_stopped_alert_sent.remove(wallet_address)
 
 if __name__ == "__main__":
     main()

--- a/src/disputable_values_monitor/cli.py
+++ b/src/disputable_values_monitor/cli.py
@@ -39,8 +39,13 @@ from disputable_values_monitor.utils import create_async_task
 from disputable_values_monitor.utils import fetch_dashboard
 from disputable_values_monitor.discord import token_balance_alert, send_discord_msg
 
+logger = get_logger(__name__)
+
 #get wallet addresses for reporters to monitor
 reporters: list[str] = get_reporters()
+if "0x0000000000000000000000000000000000000000" in reporters:
+        logger.info("One or more addresses to monitor is the default 0x000... Check .env in telliot-feeds folder to edit/add them IF you want to receive alerts.")
+        print("\nOne or more addresses to monitor is the default 0x000...\nCheck .env in telliot-feeds folder to edit/add them IF you want to receive alerts.\n")
 
 #get thresholds, in seconds, to check if a reporter has reported or not in X
 reporters_not_reporting_threshold: list[int] = get_reporters_thresholds()
@@ -74,8 +79,6 @@ price_aggregator_logger = logging.getLogger("telliot_feeds.sources.price_aggrega
 price_aggregator_logger.handlers = [
     h for h in price_aggregator_logger.handlers if not isinstance(h, logging.StreamHandler)
 ]
-
-logger = get_logger(__name__)
 
 
 def print_title_info() -> None:
@@ -342,7 +345,6 @@ async def update_reporters_pls_balance(
     for reporter in reporters:
         if reporter in excluded_addresses:
             if not warning_sent:
-                print("Reporters' addresses to monitor token balance not set. Check .env to edit/add them.")
                 warning_sent = True
             continue
         balance = await get_pls_balance(telliot_config, reporter)
@@ -489,6 +491,11 @@ async def update_reporters_last_report(
     for i in range(len(reporters)):
         wallet_address = reporters[i]
         time_threshold = reporters_not_reporting_threshold[i]
+        
+        # Skip check if the wallet is the default value
+        if wallet_address == "0x0000000000000000000000000000000000000000":
+            continue 
+        
         current_time = int(time.time())  #gets a fresh timestamp for calcs
 
         last_report = await get_last_report(telliot_config, wallet_address)

--- a/src/disputable_values_monitor/cli.py
+++ b/src/disputable_values_monitor/cli.py
@@ -58,7 +58,7 @@ if "0x00000000000000000000000000000000000000000000000000000000000000000" in quer
         logger.info("One or more queryIDs to monitor is the default '0x000...' Check .env in telliot-feeds folder to edit/add them IF you want these alerts.")
         print("One or more queryIDs to monitor is the default '0x000...'\nLeave as is or edit .env inside /telliot-feeds if you want these alerts.\n")
 
-#get thresholds, in seconds, to check if a queryID was reported or not in X
+#get thresholds, in seconds, to check if there's a new report to desired queryIDs
 queryids_unreported_threshold: list[int] = get_queryids_thresholds()
 
 #set with reporter alerts sent so not to send duplicates
@@ -291,31 +291,7 @@ async def start(
                         cfg=cfg,
                         log=event
                     )
-                    #TODO: prob not need these too, since we don't use notification service
 
-                    # if new_dispute.reporter in reporters:
-                    #     subject = f"DVM ALERT ({os.getenv('ENV_NAME', 'default')}) - New Dispute against Reporter {new_dispute.reporter}"
-                    #     msg = format_new_dispute_message(new_dispute)
-                    #     new_dispute_against_reporter_notification_task = create_async_task(
-                    #         handle_notification_service,
-                    #         subject=subject,
-                    #         msg=msg,
-                    #         notification_service=notification_service,
-                    #         sms_message_function=lambda notification_source: dispute_alert(f"{subject}\n{msg}",
-                    #                                                                        recipients, from_number,
-                    #                                                                        notification_source),
-                    #         ses=ses,
-                    #         slack=slack,
-                    #         notification_service_results=notification_service_results,
-                    #         notification_source=NotificationSources.NEW_DISPUTE_AGAINST_REPORTER
-                    #     )
-                    #     new_dispute_against_reporter_notification_task.add_done_callback(
-                    #         lambda future_obj: notification_task_callback(
-                    #             msg=f"New Dispute Event against Reporter",
-                    #             notification_service_results=notification_service_results,
-                    #             notification_source=NotificationSources.NEW_DISPUTE_AGAINST_REPORTER
-                    #         )
-                    #     )
                     msg =(
                         f"❕NEW DISPUTE EVENT❕\n"
                         f"\nCheck the Dashboard and VOTE. Otherwise you risk forfeiting staking rewards!\n\n"

--- a/src/disputable_values_monitor/cli.py
+++ b/src/disputable_values_monitor/cli.py
@@ -4,6 +4,7 @@ import logging
 import warnings
 from time import sleep
 import time
+import sys
 
 from decimal import *
 import os
@@ -51,6 +52,11 @@ if "0x0000000000000000000000000000000000000000" in reporters:
 
 #get thresholds, in seconds, to check if a reporter has reported or not in X
 reporters_not_reporting_threshold: list[int] = get_reporters_thresholds()
+if len(reporters) != len(reporters_not_reporting_threshold):
+    msg = "Error: The number of reporters and thresholds for them must match. Check .env"
+    logger.error(msg)
+    print(msg)
+    sys.exit(1)
 
 #get queryIDs to monitor the last time they were reported
 query_ids: list[str] = get_queryids()
@@ -60,6 +66,12 @@ if "0x00000000000000000000000000000000000000000000000000000000000000000" in quer
 
 #get thresholds, in seconds, to check if there's a new report to desired queryIDs
 queryids_unreported_threshold: list[int] = get_queryids_thresholds()
+
+if len(query_ids) != len(queryids_unreported_threshold):
+    msg = "Error: The number of queryIDs and thresholds for them must match. Check .env"
+    logger.error(msg)
+    print(msg)
+    sys.exit(1)
 
 #set with reporter alerts sent so not to send duplicates
 reporter_stopped_alert_sent = set()

--- a/src/disputable_values_monitor/cli.py
+++ b/src/disputable_values_monitor/cli.py
@@ -1,4 +1,5 @@
 """CLI dashboard to display recent values reported to Tellor oracles."""
+import asyncio
 import logging
 import warnings
 from time import sleep
@@ -33,25 +34,37 @@ from disputable_values_monitor.utils import get_tx_explorer_url
 from disputable_values_monitor.utils import select_account
 from disputable_values_monitor.utils import Topics
 
-from disputable_values_monitor.data import get_fetch_balance, get_pls_balance, get_last_report
-from disputable_values_monitor.utils import get_env_reporters_balance_threshold, get_reporters, get_reporters_thresholds
+from disputable_values_monitor.data import get_fetch_balance, get_pls_balance, get_last_report, get_queryid_last_timestamp
+from disputable_values_monitor.utils import get_env_reporters_balance_threshold, get_reporters, get_reporters_thresholds, get_queryids, get_queryids_thresholds
 from disputable_values_monitor.utils import create_async_task
 from disputable_values_monitor.utils import fetch_dashboard
 from disputable_values_monitor.discord import token_balance_alert, send_discord_msg
 
 logger = get_logger(__name__)
 
-#get wallet addresses for reporters to monitor
+#get wallet addresses of reporters to monitor
 reporters: list[str] = get_reporters()
 if "0x0000000000000000000000000000000000000000" in reporters:
-        logger.info("One or more addresses to monitor is the default 0x000... Check .env in telliot-feeds folder to edit/add them IF you want to receive alerts.")
-        print("\nOne or more addresses to monitor is the default 0x000...\nCheck .env in telliot-feeds folder to edit/add them IF you want to receive alerts.\n")
+        logger.info("One or more Reporters to monitor is the default '0x000...' Check .env in telliot-feeds folder to edit/add them IF you want these alerts.")
+        print("One or more REPORTERS to monitor is the default '0x000...'\nLeave as is or edit .env inside /telliot-feeds if you want these alerts.\n")
 
 #get thresholds, in seconds, to check if a reporter has reported or not in X
 reporters_not_reporting_threshold: list[int] = get_reporters_thresholds()
 
-#set with alerts sent so not to double sent alerts
+#get queryIDs to monitor the last time they were reported
+query_ids: list[str] = get_queryids()
+if "0x00000000000000000000000000000000000000000000000000000000000000000" in query_ids:
+        logger.info("One or more queryIDs to monitor is the default '0x000...' Check .env in telliot-feeds folder to edit/add them IF you want these alerts.")
+        print("One or more queryIDs to monitor is the default '0x000...'\nLeave as is or edit .env inside /telliot-feeds if you want these alerts.\n")
+
+#get thresholds, in seconds, to check if a queryID was reported or not in X
+queryids_unreported_threshold: list[int] = get_queryids_thresholds()
+
+#set with reporter alerts sent so not to send duplicates
 reporter_stopped_alert_sent = set()
+
+#set with queryIDs alerts sent so not to send duplicates
+queryids_unreported_alert_sent = set()
 
 def get_reporters_balance_threshold(reporters: list[str], env_variable_name: str):
     reporters_threshold: list[int] = get_env_reporters_balance_threshold(env_variable_name=env_variable_name)
@@ -235,6 +248,14 @@ async def start(
             reporters_not_reporting_threshold
         )
         reporters_have_reported_task.add_done_callback(lambda future: None)
+#TODO:
+        queryid_last_report_task = create_async_task(
+            update_queryid_last_report,
+            cfg,
+            query_ids,
+            queryids_unreported_threshold
+        )
+        queryid_last_report_task.add_done_callback(lambda future: None)
         
         for event_list in event_lists:
             # event_list = [(80001, EXAMPLE_NEW_REPORT_EVENT)]
@@ -491,15 +512,20 @@ async def update_reporters_last_report(
     for i in range(len(reporters)):
         wallet_address = reporters[i]
         time_threshold = reporters_not_reporting_threshold[i]
-        
-        # Skip check if the wallet is the default value
-        if wallet_address == "0x0000000000000000000000000000000000000000":
-            continue 
-        
-        current_time = int(time.time())  #gets a fresh timestamp for calcs
 
+        if wallet_address == "0x0000000000000000000000000000000000000000":
+            continue # Skip check if the wallet is the default value
+
+        current_time = int(time.time())  # gets a fresh timestamp for calcs
         last_report = await get_last_report(telliot_config, wallet_address)
-        time_since_report = current_time - last_report
+        if last_report == 0:
+            logger.info(f'Error in get_last_report for {wallet_address}.')
+            continue
+        if last_report < current_time:
+            time_since_report = current_time - last_report
+        else:
+            logger.info(f'Timestamp for {wallet_address} in the future.')
+            continue
 
         if time_since_report > time_threshold:
             if wallet_address not in reporter_stopped_alert_sent:
@@ -516,6 +542,66 @@ async def update_reporters_last_report(
             # If the reporter has reported recently, remove them from the alert set
             if wallet_address in reporter_stopped_alert_sent:
                 reporter_stopped_alert_sent.remove(wallet_address)
+
+
+async def update_queryid_last_report(
+        telliot_config: TelliotConfig,
+        query_ids: list[str],
+        queryids_unreported_threshold: list[int]):
+    """
+    Checks the last reported time for each queryIDs and sends alerts if they were not reported within threshold.
+
+    Args:
+        telliot_config: TelliotConfig
+            query_ids: list[str]
+            queryids_unreported_threshold: list[int]
+    """
+    global queryids_unreported_alert_sent
+    if not query_ids or not queryids_unreported_threshold:
+        print("Error: 'QUERY_IDS' or 'QUERYID_LAST_REPORT_THRESHOLD' not found in .env file.")
+        logger.error("Error: 'QUERY_IDS' or 'QUERYID_LAST_REPORT_THRESHOLD' not found in .env file.")
+        return
+
+    if len(query_ids) != len(queryids_unreported_threshold):
+        print("Error: The number of values in QUERY_IDS and QUERYID_LAST_REPORT_THRESHOLD must match. Check .env")
+        logger.error("Error: The number of values in QUERY_IDS and QUERYID_LAST_REPORT_THRESHOLD must match. Check .env")
+        return
+
+    for i in range(len(query_ids)):
+        qid_address = query_ids[i]
+        time_threshold = queryids_unreported_threshold[i]
+
+        # Skip check if the queryID is the default value
+        if qid_address == "0x00000000000000000000000000000000000000000000000000000000000000000":
+            continue
+
+        current_time = int(time.time())  # gets a fresh timestamp for calcs
+        last_report = await get_queryid_last_timestamp(telliot_config, qid_address, current_time)
+        if last_report == 0:
+            logger.info(f'Error in get_queryid_last_timestamp for {qid_address}.')
+            continue
+        if last_report < current_time:
+            time_since_report = current_time - last_report
+        else:
+            logger.info(f'Timestamp for {qid_address} in the future.')
+            continue
+
+        if time_since_report > time_threshold:
+            if qid_address not in queryids_unreported_alert_sent:
+                msg = (
+                    f"\n❗QueryID Alert❗\n"
+                    f"No new reports for:\n"
+                    f"**{qid_address}** in: "
+                    f"{time_since_report} seconds. \n**Last report was:** "
+                    f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(last_report))} (Timestamp: {last_report}).\n"
+                    f"**Threshold set to send alert:** {time_threshold} seconds without a new report."
+                )
+                send_discord_msg(msg)
+                queryids_unreported_alert_sent.add(qid_address)  # Add wallet to the set after sending the alert
+        else:
+            # If the reporter has reported recently, remove them from the alert set
+            if qid_address in queryids_unreported_alert_sent:
+                queryids_unreported_alert_sent.remove(qid_address)
 
 if __name__ == "__main__":
     main()

--- a/src/disputable_values_monitor/cli.py
+++ b/src/disputable_values_monitor/cli.py
@@ -21,7 +21,7 @@ from disputable_values_monitor import WAIT_PERIOD
 from disputable_values_monitor.config import AutoDisputerConfig
 from disputable_values_monitor.data import chain_events
 from disputable_values_monitor.data import get_events
-from disputable_values_monitor.data import parse_new_report_event
+from disputable_values_monitor.data import parse_new_report_event,parse_new_dispute_event
 from disputable_values_monitor.discord import alert
 from disputable_values_monitor.discord import dispute_alert
 from disputable_values_monitor.discord import generic_alert
@@ -39,6 +39,7 @@ from disputable_values_monitor.utils import get_env_reporters_balance_threshold,
 from disputable_values_monitor.utils import create_async_task
 from disputable_values_monitor.utils import fetch_dashboard
 from disputable_values_monitor.discord import token_balance_alert, send_discord_msg
+from telliot_feeds.utils.discord import get_dashboard_url
 
 logger = get_logger(__name__)
 
@@ -62,9 +63,10 @@ queryids_unreported_threshold: list[int] = get_queryids_thresholds()
 
 #set with reporter alerts sent so not to send duplicates
 reporter_stopped_alert_sent = set()
-
 #set with queryIDs alerts sent so not to send duplicates
 queryids_unreported_alert_sent = set()
+#set with disputeIDs alerts sent so not to send duplicates
+new_dispute_even_alert_sent = set()
 
 def get_reporters_balance_threshold(reporters: list[str], env_variable_name: str):
     reporters_threshold: list[int] = get_env_reporters_balance_threshold(env_variable_name=env_variable_name)
@@ -151,7 +153,7 @@ async def start(
 ) -> None:
     """Start the CLI dashboard."""
     cfg = TelliotConfig()
-    cfg.main.chain_id = int(os.getenv("NETWORK_ID", "943")) #chain_id to select account to dispute
+    cfg.main.chain_id = int(os.getenv("NETWORK_ID", "943"))
     disp_cfg = AutoDisputerConfig(is_disputing=is_disputing, confidence_flag=confidence_threshold)
     print_title_info()
 
@@ -179,6 +181,12 @@ async def start(
             topics=[Topics.NEW_REPORT],
             inital_block_offset=initial_block_offset,
         )
+        governance_dispute_events = await get_events(
+            cfg=cfg,
+            contract_name="tellor-governance",
+            topics=[Topics.NEW_DISPUTE],
+            inital_block_offset=initial_block_offset,
+        )
         ##If using tellorflex-oracle, remove comments.
         
         #tellor_flex_report_events = await get_events(
@@ -199,7 +207,7 @@ async def start(
             topics=[[Topics.NEW_ORACLE_ADDRESS], [Topics.NEW_PROPOSED_ORACLE_ADDRESS]],
             inital_block_offset=initial_block_offset,
         )
-        event_lists += tellor360_events #+ tellor_flex_report_events
+        event_lists += governance_dispute_events #tellor360_events + tellor_flex_report_events
 
         reporters_pls_balance_task = create_async_task(
             update_reporters_pls_balance,
@@ -248,7 +256,7 @@ async def start(
             reporters_not_reporting_threshold
         )
         reporters_have_reported_task.add_done_callback(lambda future: None)
-#TODO:
+
         queryid_last_report_task = create_async_task(
             update_queryid_last_report,
             cfg,
@@ -271,6 +279,59 @@ async def start(
                     link = get_tx_explorer_url(cfg=cfg, tx_hash=event.transactionHash.hex())
                     msg = f"\n❗NEW ORACLE ADDRESS ALERT❗\n{link}"
                     generic_alert(msg=msg)
+                    continue
+
+                if HexBytes(Topics.NEW_DISPUTE) in event.topics:
+                    if event.transactionHash.hex() in new_dispute_even_alert_sent:
+                        logger.debug(f'tx hash already added to set:{event.transactionHash.hex}')
+                        continue
+                    logger.debug(f'event tx hash:{event.transactionHash.hex}')
+
+                    new_dispute = await parse_new_dispute_event(
+                        cfg=cfg,
+                        log=event
+                    )
+                    #TODO: prob not need these too, since we don't use notification service
+
+                    # if new_dispute.reporter in reporters:
+                    #     subject = f"DVM ALERT ({os.getenv('ENV_NAME', 'default')}) - New Dispute against Reporter {new_dispute.reporter}"
+                    #     msg = format_new_dispute_message(new_dispute)
+                    #     new_dispute_against_reporter_notification_task = create_async_task(
+                    #         handle_notification_service,
+                    #         subject=subject,
+                    #         msg=msg,
+                    #         notification_service=notification_service,
+                    #         sms_message_function=lambda notification_source: dispute_alert(f"{subject}\n{msg}",
+                    #                                                                        recipients, from_number,
+                    #                                                                        notification_source),
+                    #         ses=ses,
+                    #         slack=slack,
+                    #         notification_service_results=notification_service_results,
+                    #         notification_source=NotificationSources.NEW_DISPUTE_AGAINST_REPORTER
+                    #     )
+                    #     new_dispute_against_reporter_notification_task.add_done_callback(
+                    #         lambda future_obj: notification_task_callback(
+                    #             msg=f"New Dispute Event against Reporter",
+                    #             notification_service_results=notification_service_results,
+                    #             notification_source=NotificationSources.NEW_DISPUTE_AGAINST_REPORTER
+                    #         )
+                    #     )
+                    msg =(
+                        f"❕NEW DISPUTE EVENT❕\n"
+                        f"\nCheck the Dashboard and VOTE. Otherwise you risk forfeiting staking rewards!\n\n"
+                        f"- Chain ID: {new_dispute.chain_id}\n"
+                        f"- Dispute ID: {new_dispute.dispute_id}\n"
+                        f"- Reporter: {new_dispute.reporter}\n"
+                        f"- Disputer: {new_dispute.initiator}\n"
+                        f"- Start date: {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(new_dispute.startDate))}"
+                        f" (Timestamp: {new_dispute.startDate})\n"
+                        f"- Vote round: {new_dispute.voteRound}\n"
+                        f"**Vote here:** {get_dashboard_url(str(new_dispute.chain_id), 'vote')}"
+
+                    )
+                    new_dispute_even_alert_sent.add(new_dispute.tx_hash)
+                    logger.debug(f'new tx hash added to set{new_dispute.tx_hash}')
+                    send_discord_msg(msg)
                     continue
 
                 try:

--- a/src/disputable_values_monitor/data.py
+++ b/src/disputable_values_monitor/data.py
@@ -652,7 +652,7 @@ async def get_last_report(cfg: TelliotConfig, address: str) -> int:
     try:
         contract = get_contract_token_alerts(cfg, account=(int(os.getenv("NETWORK_ID", "943"))), name="tellor360-oracle")
     except Exception as e:
-        logger.error(f"Error getting contract for address {address}: {e}")
+        logger.error(f"Error getting contract info for get_last_report: {e}")
         return 0 
 
     #get staker info to get last report
@@ -665,4 +665,25 @@ async def get_last_report(cfg: TelliotConfig, address: str) -> int:
         return (last_report[4])
     except Exception as e:
         logger.error(f"Error getting last report for address {address}: {e}")
-        return 0 
+        return 0
+
+async def get_queryid_last_timestamp(cfg: TelliotConfig, qid_address: str, timestamp: int) -> int:
+    """ Get the last time a queryID from .env was submitted"""
+    #gets contract info
+    try:
+        contract = get_contract_token_alerts(cfg, account=(int(os.getenv("NETWORK_ID", "943"))), name="tellor360-oracle")
+    except Exception as e:
+        logger.error(f"Error getting contract info for get_queryid_last_timestamp: {e}")
+        return 0
+
+    #call getDataBefore to check when was the last submission for the queryID
+    try:
+        last_report, status = await contract.read("getDataBefore", qid_address, timestamp)
+        logger.debug(f'Last submission: {qid_address}: {last_report[2]}')
+        if not status.ok:
+            logger.warning(f"Status not ok for {qid_address} last report. Status: {status}")
+            return 0
+        return last_report[2]
+    except Exception as e:
+        logger.error(f"Error getting last report for qid_address {qid_address}: {e}")
+        return 0

--- a/src/disputable_values_monitor/data.py
+++ b/src/disputable_values_monitor/data.py
@@ -345,7 +345,7 @@ async def chain_events(
                 endpoint.connect()
                 w3 = endpoint.web3
             except (IndexError, ValueError) as e:
-                logger.error(f"Unable to connect to endpoint on chain_id {chain_id}: {e}")
+                logger.error(f"chain_events: Unable to connect to endpoint on chain_id {chain_id}: {e}")
                 continue
             events_loop.append(log_loop(w3, chain_id, address, topic, inital_block_offset))
     events: List[List[tuple[int, Any]]] = await asyncio.gather(*events_loop)
@@ -364,10 +364,11 @@ async def get_events(
         if endpoint.url.endswith("{INFURA_API_KEY}"):
             continue
         chain_id = endpoint.chain_id
+        logger.debug(f"get_events: chain_id = {chain_id}")
         try:
             endpoint.connect()
         except Exception as e:
-            logger.warning(f"unable to connect to endpoint for chain_id {chain_id}: {e}")
+            logger.warning(f"get_events: unable to connect to endpoint for chain_id {chain_id}: {e}")
             continue
 
         w3 = endpoint.web3
@@ -442,7 +443,7 @@ async def parse_new_report_event(
             endpoint.connect()
             w3 = endpoint.web3
         except ValueError as e:
-            logger.error(f"Unable to connect to endpoint on chain_id {chain_id}: {e}")
+            logger.error(f"parse_new_report_event: Unable to connect to endpoint on chain_id {chain_id}: {e}")
             return None
 
         codec = w3.codec
@@ -575,7 +576,7 @@ def get_block_number_at_timestamp(cfg: TelliotConfig, timestamp: int) -> Any:
         endpoint = cfg.get_endpoint()
         endpoint.connect()
     except ValueError as e:
-        logger.error(f"Unable to connect to endpoint on chain_id {cfg.main.chain_id}: {e}")
+        logger.error(f"get_block_number_at_timestamp: Unable to connect to endpoint on chain_id {cfg.main.chain_id}: {e}")
         return None
 
     w3 = endpoint.web3
@@ -644,3 +645,24 @@ async def get_pls_balance(cfg: TelliotConfig, address: str) -> Optional[Decimal]
     balance_wei = w3.eth.getBalance(address)
     balance = Decimal(w3.fromWei(balance_wei, 'ether'))
     return balance
+    
+async def get_last_report(cfg: TelliotConfig, address: str) -> int:
+    """ Get the last time a reporter from .env has reported"""
+    #gets contract info
+    try:
+        contract = get_contract_token_alerts(cfg, account=(int(os.getenv("NETWORK_ID", "943"))), name="tellor360-oracle")
+    except Exception as e:
+        logger.error(f"Error getting contract for address {address}: {e}")
+        return 0 
+
+    #get staker info to get last report
+    try:
+        last_report, status = await contract.read("getStakerInfo", Web3.toChecksumAddress(address))
+        logger.debug(f'{last_report[4]}')
+        if not status.ok:
+            logger.warning(f"Status not ok for {address} last report. Status: {status}")
+            return 0
+        return (last_report[4])
+    except Exception as e:
+        logger.error(f"Error getting last report for address {address}: {e}")
+        return 0 

--- a/src/disputable_values_monitor/data.py
+++ b/src/disputable_values_monitor/data.py
@@ -35,13 +35,13 @@ from web3.middleware import geth_poa_middleware
 from web3.types import LogReceipt
 
 from disputable_values_monitor import ALWAYS_ALERT_QUERY_TYPES
-from disputable_values_monitor import NEW_REPORT_ABI
+from disputable_values_monitor import NEW_REPORT_ABI, NEW_DISPUTE_ABI
 from disputable_values_monitor.discord import send_discord_msg
 from disputable_values_monitor.utils import are_all_attributes_none
 from disputable_values_monitor.utils import disputable_str
 from disputable_values_monitor.utils import get_logger
 from disputable_values_monitor.utils import get_tx_explorer_url
-from disputable_values_monitor.utils import NewReport
+from disputable_values_monitor.utils import NewReport,NewDispute
 
 import os
 from dotenv import load_dotenv
@@ -419,6 +419,45 @@ def get_source_from_data(query_data: bytes) -> Optional[DataSource]:
         setattr(source, key, value)
     return source
 
+
+async def parse_new_dispute_event(
+        cfg: TelliotConfig,
+        log: LogReceipt
+) -> Optional[NewDispute]:
+    chain_id = cfg.main.chain_id
+    endpoint = cfg.endpoints.find(chain_id=chain_id)[0]
+
+    new_dispute = NewDispute()
+
+    if not endpoint:
+        logger.error(f"Unable to find a suitable endpoint for chain_id {chain_id}")
+        return None
+
+    try:
+        endpoint.connect()
+        w3 = endpoint.web3
+    except ValueError as e:
+        logger.error(f"Unable to connect to endpoint on chain_id {chain_id}: {e}")
+        return None
+
+    codec = w3.codec
+    event_data = get_event_data(codec, NEW_DISPUTE_ABI, log)
+
+    new_dispute.tx_hash = event_data.transactionHash.hex()
+    new_dispute.chain_id = chain_id
+    new_dispute.dispute_id = event_data.args._disputeId
+    new_dispute.reporter = event_data.args._reporter
+    new_dispute.query_id = "0x" + event_data.args._queryId.hex()
+    new_dispute.initiator = event_data.args._initiator
+    new_dispute.timestamp = event_data.args._timestamp
+    new_dispute.startDate = event_data.args._startDate
+    new_dispute.voteRound = event_data.args._voteRound
+    new_dispute.fee = event_data.args._fee
+    new_dispute.voteRoundLength = event_data.args._voteRoundLength
+    new_dispute.link = get_tx_explorer_url(tx_hash=new_dispute.tx_hash, cfg=cfg)
+    new_dispute.blockNumber = event_data.blockNumber
+
+    return new_dispute
 
 async def parse_new_report_event(
     cfg: TelliotConfig,

--- a/src/disputable_values_monitor/discord.py
+++ b/src/disputable_values_monitor/discord.py
@@ -24,11 +24,11 @@ def generic_alert(msg: str) -> None:
 
 def get_alert_bot_1() -> Discord:
     """Read the Discord webhook url from the environment."""
-    DISCORD_WEBHOOK_URL_1 = os.getenv("DISCORD_WEBHOOK_URL_1")
-    if DISCORD_WEBHOOK_URL_1 is None:
+    discord_webhook_url_1 = os.getenv("DISCORD_WEBHOOK_URL_1")
+    if discord_webhook_url_1 is None:
+        logger.error(f"At least one DISCORD_WEBHOOK_URL is required. Check .env before running the 'cli' command.")
         raise Exception("At least one DISCORD_WEBHOOK_URL is required. Check .env before running the 'cli' command.")
-        logger.info(f"At least one DISCORD_WEBHOOK_URL is required. Check .env before running the 'cli' command.")
-    alert_bot_1 = Discord(url=DISCORD_WEBHOOK_URL_1)
+    alert_bot_1 = Discord(url=discord_webhook_url_1)
     return alert_bot_1
 
 
@@ -92,13 +92,13 @@ def generate_alert_msg(disputable: bool, new_report: str) -> str:
 
 def send_discord_msg(msg: str) -> None:
     """Send Discord alert."""
-    MONITOR_NAME = os.getenv("MONITOR_NAME")
-    message = f"❗{MONITOR_NAME} Found Something❗\n"
+    monitor_name = os.getenv("MONITOR_NAME")
+    message = f"{monitor_name} Found Something:\n"
     get_alert_bot_1().post(content=message + msg)
     logger.info(f"Alert sent bot 1: {msg}")
     
-    DISCORD_WEBHOOK_URL_2 = os.getenv("DISCORD_WEBHOOK_URL_2")
-    if not DISCORD_WEBHOOK_URL_2:
+    discord_webhook_url_2 = os.getenv("DISCORD_WEBHOOK_URL_2")
+    if not discord_webhook_url_2:
         pass
     else:
         try:
@@ -108,8 +108,8 @@ def send_discord_msg(msg: str) -> None:
             click.echo(f"alert bot 2 not used? {e}")
             logger.info(f"alert bot 2 not used? {e}")
         pass
-    DISCORD_WEBHOOK_URL_3 = os.getenv("DISCORD_WEBHOOK_URL_3")
-    if not DISCORD_WEBHOOK_URL_3:
+    discord_webhook_url_3 = os.getenv("DISCORD_WEBHOOK_URL_3")
+    if not discord_webhook_url_3:
         pass
     else:
         try:

--- a/src/disputable_values_monitor/discord.py
+++ b/src/disputable_values_monitor/discord.py
@@ -26,17 +26,18 @@ def get_alert_bot_1() -> Discord:
     """Read the Discord webhook url from the environment."""
     DISCORD_WEBHOOK_URL_1 = os.getenv("DISCORD_WEBHOOK_URL_1")
     if DISCORD_WEBHOOK_URL_1 is None:
-        raise Exception("At least one DISCORD_WEBHOOK_URL is required. See docs or run 'source vars.sh' before the 'cli' command.")
+        raise Exception("At least one DISCORD_WEBHOOK_URL is required. Check .env before running the 'cli' command.")
+        logger.info(f"At least one DISCORD_WEBHOOK_URL is required. Check .env before running the 'cli' command.")
     alert_bot_1 = Discord(url=DISCORD_WEBHOOK_URL_1)
     return alert_bot_1
 
 
 def get_alert_bot_2() -> Discord:
-    return Discord(url=os.getenv("DISCORD_WEBHOOK_URL_2"))
+        return Discord(url=os.getenv("DISCORD_WEBHOOK_URL_2"))
 
 
 def get_alert_bot_3() -> Discord:
-    return Discord(url=os.getenv("DISCORD_WEBHOOK_URL_3"))
+        return Discord(url=os.getenv("DISCORD_WEBHOOK_URL_3"))
     
 def token_balance_alert(msg: str) -> None:
     """send an alert when FETCH or PLS are below the threshold"""
@@ -68,6 +69,7 @@ def alert(all_values: bool, new_report: Any) -> None:
     if all_values:
         msg = generate_alert_msg(False, new_report)
         send_discord_msg(msg)
+        
 
     else:
         if new_report.disputable:
@@ -93,15 +95,29 @@ def send_discord_msg(msg: str) -> None:
     MONITOR_NAME = os.getenv("MONITOR_NAME")
     message = f"❗{MONITOR_NAME} Found Something❗\n"
     get_alert_bot_1().post(content=message + msg)
-    try:
-        get_alert_bot_2().post(content=message + msg)
-    except Exception as e:
-        click.echo(f"alert bot 2 not used? {e}")
+    logger.info(f"Alert sent bot 1: {msg}")
+    
+    DISCORD_WEBHOOK_URL_2 = os.getenv("DISCORD_WEBHOOK_URL_2")
+    if not DISCORD_WEBHOOK_URL_2:
         pass
-    try:
-        get_alert_bot_3().post(content=message + msg)
-    except Exception as e:
-        click.echo(f"alert bot 3 not used? {e}")
+    else:
+        try:
+            get_alert_bot_2().post(content=message + msg)
+            logger.info(f"Alert sent bot 2: {msg}")
+        except Exception as e:
+            click.echo(f"alert bot 2 not used? {e}")
+            logger.info(f"alert bot 2 not used? {e}")
         pass
-    click.echo("Alerts sent!")
+    DISCORD_WEBHOOK_URL_3 = os.getenv("DISCORD_WEBHOOK_URL_3")
+    if not DISCORD_WEBHOOK_URL_3:
+        pass
+    else:
+        try:
+            get_alert_bot_3().post(content=message + msg)
+            logger.info(f"Alert sent bot 3: {msg}")
+        except Exception as e:
+            click.echo(f"alert bot 3 not used? {e}")
+            logger.info(f"alert bot 3 not used? {e}")
+        pass
+    click.echo("Alert sent! dvmLog.txt for more info.")
     return

--- a/src/disputable_values_monitor/utils.py
+++ b/src/disputable_values_monitor/utils.py
@@ -157,6 +157,14 @@ def get_reporters_thresholds():
     thresholds = [int(t.strip()) for t in os.getenv('NO_REPORTING_THRESHOLD', "").split(",")]
     return [threshold for threshold in thresholds if threshold != ""]
 
+def get_queryids():
+    queryids = [queryid.strip() for queryid in os.getenv('QUERY_IDS', "").split(',')]
+    return [queryid for queryid in queryids if queryid != ""]
+
+def get_queryids_thresholds():
+    thresholds = [int(t.strip()) for t in os.getenv('QUERYID_LAST_REPORT_THRESHOLD', "").split(",")]
+    return [threshold for threshold in thresholds if threshold != ""]
+
 
 def create_async_task(function, *args, **kwargs):
     return asyncio.create_task(function(*args, **kwargs))

--- a/src/disputable_values_monitor/utils.py
+++ b/src/disputable_values_monitor/utils.py
@@ -113,7 +113,7 @@ def get_logger(name: str) -> logging.Logger:
     fh.setFormatter(formatter)
     logger = logging.getLogger(name)
     logger.addHandler(fh)
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
     return logger
 
 
@@ -152,6 +152,11 @@ def get_env_reporters_balance_threshold(env_variable_name: str):
 def get_reporters():
     reporters = [reporter.strip() for reporter in os.getenv('REPORTERS', "").split(',')]
     return [Web3.toChecksumAddress(reporter) for reporter in reporters if reporter != ""]
+
+def get_reporters_thresholds():
+    thresholds = [int(t.strip()) for t in os.getenv('NO_REPORTING_THRESHOLD', "").split(",")]
+    return [threshold for threshold in thresholds if threshold != ""]
+
 
 def create_async_task(function, *args, **kwargs):
     return asyncio.create_task(function(*args, **kwargs))

--- a/src/disputable_values_monitor/utils.py
+++ b/src/disputable_values_monitor/utils.py
@@ -42,7 +42,26 @@ class Topics:
     NEW_PROPOSED_ORACLE_ADDRESS: str = (
         "0x8fe6b09081e9ffdaf91e337aba6769019098771106b34b194f1781b7db1bf42b"  # oracle.NewProposedOracleAddress
     )
+    # Keccak256("NewDispute(uint256,bytes32,uint256,address,address,uint256,uint256,uint256,uint256)")
+    NEW_DISPUTE: str = "0xfbfeca72a80efb0d1aabf7f937aaec719fa5c81548a4ade65b40ecdec0afca4e"
 
+@dataclass
+class NewDispute:
+    """NewDispute event."""
+
+    tx_hash: str = ""
+    timestamp: int = 0
+    reporter: str = ""
+    query_id: str = ""
+    dispute_id: int = 0
+    initiator: str = ""
+    chain_id: int = 0
+    link: str = ""
+    blockNumber: int = 0
+    startDate: int = 0
+    voteRound: int = 0
+    fee: int = 0
+    voteRoundLength: int = 0
 
 @dataclass
 class NewReport:


### PR DESCRIPTION
- Message when starting DVM with default values in .env

Warn the user they need to set up the .env if they want to monitor extra features

- Stops DVM if QueryIDs and Reporters vars don’t match their thresholds length

- Alert when single or multiple reporter’s addresses have stopped reporting

- Alert when single or multiple queryIDs have not updated in a period of time

- Alert when there’s a new dispute on chain with quick link to the dashboard